### PR TITLE
IBM Cloud IDE enviroment is too old for new packages

### DIFF
--- a/labs/03_test_fixtures/requirements.txt
+++ b/labs/03_test_fixtures/requirements.txt
@@ -1,9 +1,6 @@
 # Dependecies for this lab
-Werkzeug==2.1.1
-Flask==2.1.1
-SQLAlchemy==1.4.35
-Flask-SQLAlchemy==2.5.1
-nose==1.3.7
-pinocchio==0.4.3
-coverage==6.3.2
-factory-boy==3.2.1
+Flask
+Flask-SQLAlchemy
+nose
+pinocchio
+coverage


### PR DESCRIPTION
Removing version numbers because you never know what you will get in the IBM environment