### PR TITLE
Changes required for resolving Runtime & Value errors using Python3.8 after labs were upgraded in CloudIDE2.0

### DIFF
--- a/labs/03_test_fixtures/models/account.py
+++ b/labs/03_test_fixtures/models/account.py
@@ -20,7 +20,6 @@ class Account(db.Model):
     email = db.Column(db.String(64))
     phone_number = db.Column(db.String(32), nullable=True)
     disabled = db.Column(db.Boolean(), nullable=False, default=False)
-    date_joined = db.Column(db.Date, nullable=False, server_default=func.now())
 
     def __repr__(self):
         return '<Account %r>' % self.name

--- a/labs/03_test_fixtures/tests/test_account.py
+++ b/labs/03_test_fixtures/tests/test_account.py
@@ -3,7 +3,7 @@ Test Cases TestAccountModel
 """
 import json
 from unittest import TestCase
-from models import db
+from models import app, db
 from models.account import Account
 
 ACCOUNT_DATA = {}

--- a/labs/04_test_coverage/models/account.py
+++ b/labs/04_test_coverage/models/account.py
@@ -20,7 +20,6 @@ class Account(db.Model):
     email = db.Column(db.String(64))
     phone_number = db.Column(db.String(32), nullable=True)
     disabled = db.Column(db.Boolean(), nullable=False, default=False)
-    date_joined = db.Column(db.Date, nullable=False, server_default=func.now())
 
     def __repr__(self):
         return '<Account %r>' % self.name

--- a/labs/04_test_coverage/tests/test_account.py
+++ b/labs/04_test_coverage/tests/test_account.py
@@ -4,7 +4,7 @@ Test Cases TestAccountModel
 import json
 from random import randrange
 from unittest import TestCase
-from models import db
+from models import app, db
 from models.account import Account, DataValidationError
 
 ACCOUNT_DATA = {}

--- a/labs/04_test_coverage/tests/test_account.py
+++ b/labs/04_test_coverage/tests/test_account.py
@@ -15,6 +15,9 @@ class TestAccountModel(TestCase):
     @classmethod
     def setUpClass(cls):
         """ Load data needed by tests """
+        cls.app = app.test_client()
+        cls.app_context = app.app_context()
+        cls.app_context.push()
         db.create_all()  # make our sqlalchemy tables
         global ACCOUNT_DATA
         with open('tests/fixtures/account_data.json') as json_data:

--- a/labs/05_factories_and_fakes/models/account.py
+++ b/labs/05_factories_and_fakes/models/account.py
@@ -20,7 +20,6 @@ class Account(db.Model):
     email = db.Column(db.String(64))
     phone_number = db.Column(db.String(32), nullable=True)
     disabled = db.Column(db.Boolean(), nullable=False, default=False)
-    date_joined = db.Column(db.Date, nullable=False, server_default=func.now())
 
     def __repr__(self):
         return '<Account %r>' % self.name

--- a/labs/05_factories_and_fakes/tests/test_account.py
+++ b/labs/05_factories_and_fakes/tests/test_account.py
@@ -4,7 +4,7 @@ Test Cases TestAccountModel
 import json
 from random import randrange
 from unittest import TestCase
-from models import db
+from models import app, db
 from models.account import Account, DataValidationError
 
 ACCOUNT_DATA = {}

--- a/labs/05_factories_and_fakes/tests/test_account.py
+++ b/labs/05_factories_and_fakes/tests/test_account.py
@@ -15,6 +15,9 @@ class TestAccountModel(TestCase):
     @classmethod
     def setUpClass(cls):
         """ Load data needed by tests """
+        cls.app = app.test_client()
+        cls.app_context = app.app_context()
+        cls.app_context.push()
         db.create_all()  # make our sqlalchemy tables
         global ACCOUNT_DATA
         with open('tests/fixtures/account_data.json') as json_data:

--- a/labs/05_factories_and_fakes/tests/test_account.py
+++ b/labs/05_factories_and_fakes/tests/test_account.py
@@ -71,7 +71,6 @@ class TestAccountModel(TestCase):
         self.assertEqual(account.email, result["email"])
         self.assertEqual(account.phone_number, result["phone_number"])
         self.assertEqual(account.disabled, result["disabled"])
-        self.assertEqual(account.date_joined, result["date_joined"])
 
     def test_from_dict(self):
         """ Test account from dict """


### PR DESCRIPTION

We are now facing the below errors, using Python3.8 after the labs were upgraded in CloudIDE2.0:
1. "RuntimeError: Working outside of application context."
2. "ValueError: Invalid isoformat string……”
 
We had to make changes in these files: 1)  tests/test_account.py & 2) models/account.py  -  to resolve these errors & get the  labs working correctly.
Since the labs are divided into folders, we need to port the fixes in the other labs.

Hence, these changes are needed for the labs:
1.  https://www.coursera.org/learn/test-and-behavior-driven-development-tdd-bdd/ungradedLti/nHRcT/creating-an-initial-state-using-test-fixtures
2.  https://www.coursera.org/learn/test-and-behavior-driven-development-tdd-bdd/ungradedLti/GVlfE/running-test-cases-with-coverage
3. https://www.coursera.org/learn/test-and-behavior-driven-development-tdd-bdd/ungradedLti/KAbA4/using-factories-and-fakes