### PR TITLE
Locked down versions for all requirements

### DIFF
--- a/labs/02_writing_test_assertions/requirements.txt
+++ b/labs/02_writing_test_assertions/requirements.txt
@@ -1,5 +1,5 @@
 # Dependencies for this lab
-nose
-pinocchio
-coverage
-pylint
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+pylint==2.14.0

--- a/labs/03_test_fixtures/requirements.txt
+++ b/labs/03_test_fixtures/requirements.txt
@@ -1,7 +1,13 @@
+# Pin dependancies that might cause breakage
+Werkzeug==2.1.2
+SQLAlchemy==1.4.46
+
 # Dependencies for this lab
-Flask
-Flask-SQLAlchemy
-nose
-pinocchio
-coverage
-pylint
+Flask==2.1.2
+Flask-SQLAlchemy==2.5.1
+
+# Testing dependencies
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+pylint==2.14.0

--- a/labs/04_test_coverage/requirements.txt
+++ b/labs/04_test_coverage/requirements.txt
@@ -1,7 +1,13 @@
+# Pin dependancies that might cause breakage
+Werkzeug==2.1.2
+SQLAlchemy==1.4.46
+
 # Dependencies for this lab
-Flask
-Flask-SQLAlchemy
-nose
-pinocchio
-coverage
-pylint
+Flask==2.1.2
+Flask-SQLAlchemy==2.5.1
+
+# Testing dependencies
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+pylint==2.14.0

--- a/labs/05_factories_and_fakes/requirements.txt
+++ b/labs/05_factories_and_fakes/requirements.txt
@@ -1,8 +1,14 @@
+# Pin dependancies that might cause breakage
+Werkzeug==2.1.2
+SQLAlchemy==1.4.46
+
 # Dependencies for this lab
-Flask
-Flask-SQLAlchemy
-nose
-pinocchio
-coverage
-factory-boy
-pylint
+Flask==2.1.2
+Flask-SQLAlchemy==2.5.1
+
+# Testing dependencies
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+factory-boy==2.12.0
+pylint==2.14.0

--- a/labs/06_mocking_objects/requirements.txt
+++ b/labs/06_mocking_objects/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies for this lab
-requests
-nose
-pinocchio
-coverage
-pylint
+requests==2.31.0
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+pylint==2.14.0

--- a/labs/07_practicing_tdd/requirements.txt
+++ b/labs/07_practicing_tdd/requirements.txt
@@ -1,6 +1,11 @@
+# Pin dependancies that might cause breakage
+Werkzeug==2.1.2
+
 # Dependencies for this lab
-Flask
-nose
-pinocchio
-coverage
-pylint
+Flask==2.1.2
+
+# Testing dependencies
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+pylint==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,15 @@
+# Pin dependancies that might cause breakage
+Werkzeug==2.1.2
+SQLAlchemy==1.4.46
+
 # Dependencies for all lab
-Flask
-Flask-SQLAlchemy
-requests
+Flask==2.1.2
+Flask-SQLAlchemy==2.5.1
+requests==2.31.0
 
 # Testing dependencies
-nose
-pinocchio
-coverage
-factory-boy
-pylint
+nose==1.3.7
+pinocchio==0.4.3
+coverage==6.3.2
+factory-boy==2.12.0
+pylint==2.14.0


### PR DESCRIPTION
Made the following changes:

- Locked down all of the versions in all of the TDD labs `requirements.txt` files because SQLAlchemy introduced breaking changes.

This should eliminate any code breakage in the future.