### PR TITLE
Upgrade selenium

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -16,7 +16,7 @@ echo "export PATH=$HOME/local/bin:$PATH" >> ~/.bashrc
 
 echo "Installing Selenium and Chrome for BDD"
 sudo apt-get update
-sudo DEBIAN_FRONTEND=noninteractive apt-get install -y sqlite3 chromium-driver python3-selenium
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y sqlite3 python3-selenium
 
 echo "Starting the Postgres Docker container..."
 make app

--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -4,10 +4,10 @@ echo " Setting up BDD Environment"
 echo "****************************************"
 
 echo "Making Python 3.8 the default..."
-sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1
+sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
 
 echo "Checking the Python version..."
-python3 --version
+python --version
 
 echo "Configuring the developer environment..."
 echo "# BDD Lab Additions" >> ~/.bashrc

--- a/labs/08_environment_setup/requirements.txt
+++ b/labs/08_environment_setup/requirements.txt
@@ -1,5 +1,5 @@
-# Behavior Driven Development
+# Behavior Driven Development dependencies
 behave==1.2.6
-selenium==3.141.0
+selenium==4.16.0
 compare==0.2b0
-requests==2.27.1
+requests==2.31.0

--- a/labs/10_loading_test_data/requirements.txt
+++ b/labs/10_loading_test_data/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.16.0
 compare==0.2b0
-requests==2.28.2
+requests==2.31.0

--- a/labs/11_generating_steps/requirements.txt
+++ b/labs/11_generating_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.16.0
 compare==0.2b0
-requests==2.28.2
+requests==2.31.0

--- a/labs/12_implementing_steps/requirements.txt
+++ b/labs/12_implementing_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.16.0
 compare==0.2b0
-requests==2.28.2
+requests==2.31.0

--- a/labs/13_variable_substitution/requirements.txt
+++ b/labs/13_variable_substitution/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.16.0
 compare==0.2b0
-requests==2.28.2
+requests==2.31.0


### PR DESCRIPTION
Made the following changes:

- Removed the installation of `chromium-driver` from `setup.sh`
- Fixed syntax in `setup.sh` to make Python 3.8 the default `python` command
- Updated the `selenium` package to 4.16.0. This is the highest level that can be used. Anything higher will break.