### PR TITLE
Rolled back to older selenium API

### DIFF
--- a/labs/08_environment_setup/requirements.txt
+++ b/labs/08_environment_setup/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.16.0
+selenium==4.1.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/10_loading_test_data/requirements.txt
+++ b/labs/10_loading_test_data/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.16.0
+selenium==4.1.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/11_generating_steps/requirements.txt
+++ b/labs/11_generating_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.16.0
+selenium==4.1.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/12_implementing_steps/requirements.txt
+++ b/labs/12_implementing_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.16.0
+selenium==4.1.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/13_variable_substitution/requirements.txt
+++ b/labs/13_variable_substitution/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.16.0
+selenium==4.1.0
 compare==0.2b0
 requests==2.31.0


### PR DESCRIPTION
The new Selenium API removed calls that we teach in the class therefore we need them in the lab until the class videos have been updated. Moved back to selenium 4.1.0.