### PR TITLE
Updated lab 10 code to work with selenium 4.19.0

### DIFF
--- a/labs/10_loading_test_data/features/steps/web_steps.py
+++ b/labs/10_loading_test_data/features/steps/web_steps.py
@@ -23,14 +23,14 @@ def step_impl(context):
 @when('I set the "{element_name}" to "{text_string}"')
 def step_impl(context, element_name, text_string):
     element_id = ID_PREFIX + element_name.lower().replace(' ', '_')
-    element = context.driver.find_element_by_id(element_id)
+    element = context.driver.find_element(By.ID, element_id)
     element.clear()
     element.send_keys(text_string)
 
 @when('I click the "{button}" button')
 def step_impl(context, button):
     button_id = button.lower() + '-btn'
-    context.driver.find_element_by_id(button_id).click()
+    context.driver.find_element(By.ID, button_id).click()
 
 @then('I should see the message "{message}"')
 def step_impl(context, message):
@@ -54,6 +54,6 @@ def step_impl(context, name):
 
 @then('I should not see "{name}" in the results')
 def step_impl(context, name):
-    element = context.driver.find_element_by_id('search_results')
+    element = context.driver.find_element(By.ID, 'search_results')
     error_msg = "I should not see '%s' in '%s'" % (name, element.text)
     ensure(name in element.text, False, error_msg)

--- a/labs/10_loading_test_data/requirements.txt
+++ b/labs/10_loading_test_data/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.19.0
 compare==0.2b0
 requests==2.31.0


### PR DESCRIPTION
The new chrome driver that is installed in the new Cloud IDE environment is not compatible with selenium < 4.12 and selenium 4.12 changes the API to remove `find_element_by_id()` so the code needed to be changed to `find_element(By.ID, element_name)` even though this is not the API we teach in the lecture.

Made the following changes:

- Updated selenium to 4.19.0 in the lab 10 `requirements.txt` file
- Updated the `web_steps.py` file to use the new API call.