### PR TITLE
Upgraded all labs to selenium 4.19.0

### DIFF
--- a/labs/08_environment_setup/requirements.txt
+++ b/labs/08_environment_setup/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.19.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/11_generating_steps/requirements.txt
+++ b/labs/11_generating_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.19.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/12_implementing_steps/features/steps/web_steps.py
+++ b/labs/12_implementing_steps/features/steps/web_steps.py
@@ -8,6 +8,7 @@ For information on Waiting until elements are present in the HTML see:
 """
 
 from behave import given, when, then
+from selenium.webdriver.common.by import By
 
 @given('I am on the "Home Page"')
 def step_impl(context):

--- a/labs/12_implementing_steps/requirements.txt
+++ b/labs/12_implementing_steps/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.19.0
 compare==0.2b0
 requests==2.31.0

--- a/labs/13_variable_substitution/features/steps/web_steps.py
+++ b/labs/13_variable_substitution/features/steps/web_steps.py
@@ -8,6 +8,7 @@ For information on Waiting until elements are present in the HTML see:
 """
 
 from behave import given, when, then
+from selenium.webdriver.common.by import By
 
 @given('I am on the "Home Page"')
 def step_impl(context):
@@ -15,31 +16,31 @@ def step_impl(context):
 
 @when('I set the "Category" to "dog"')
 def step_impl(context):
-    element = context.driver.find_element_by_id('pet_category')
+    element = context.driver.find_element(By.ID, 'pet_category')
     element.clear()
     element.send_keys('dog')
 
 @when('I click the "Search" button')
 def step_impl(context):
-    element = context.driver.find_element_by_id('search-btn')
+    element = context.driver.find_element(By.ID, 'search-btn')
     element.click()
 
 @then('I should see the message "Success"')
 def step_impl(context):
-    element = context.driver.find_element_by_id('flash_message')
+    element = context.driver.find_element(By.ID, 'flash_message')
     assert "Success" in element.text
 
 @then('I should see "Fido" in the results')
 def step_impl(context):
-    element = context.driver.find_element_by_id('search_results')
+    element = context.driver.find_element(By.ID, 'search_results')
     assert "Fido" in element.text
 
 @then('I should not see "Kitty" in the results')
 def step_impl(context):
-    element = context.driver.find_element_by_id('search_results')
+    element = context.driver.find_element(BY.ID, 'search_results')
     assert "Kitty" not in element.text
 
 @then('I should not see "Leo" in the results')
 def step_impl(context):
-    element = context.driver.find_element_by_id('search_results')
+    element = context.driver.find_element(By.ID, 'search_results')
     assert "Leo" not in element.text

--- a/labs/13_variable_substitution/features/steps/web_steps.py
+++ b/labs/13_variable_substitution/features/steps/web_steps.py
@@ -37,7 +37,7 @@ def step_impl(context):
 
 @then('I should not see "Kitty" in the results')
 def step_impl(context):
-    element = context.driver.find_element(BY.ID, 'search_results')
+    element = context.driver.find_element(By.ID, 'search_results')
     assert "Kitty" not in element.text
 
 @then('I should not see "Leo" in the results')

--- a/labs/13_variable_substitution/requirements.txt
+++ b/labs/13_variable_substitution/requirements.txt
@@ -1,5 +1,5 @@
 # Behavior Driven Development dependencies
 behave==1.2.6
-selenium==4.1.0
+selenium==4.19.0
 compare==0.2b0
 requests==2.31.0


### PR DESCRIPTION
Decided to update the Lab environment to Python 3.11 with Selenium 4.19.0. 

This required updating the removed API calls:

```python
context.driver.find_element_by_id('element_name')
```

with:

```python
from selenium.webdriver.common.by import By


context.driver.find_element(By.ID, 'element_name')
```

This PR should remain in `draft` mode until the lab instructions have been changed and published to Coursera.